### PR TITLE
Mock lifecycle

### DIFF
--- a/.github/workflows/lint_test_release.yaml
+++ b/.github/workflows/lint_test_release.yaml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Install Python 3.8.5
+    - name: Install Python 3.9.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8.5
+        python-version: 3.9.10
     - name: Install Python Dependencies
       run: |
         pip install --upgrade pip setuptools
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Install Python 3.8.5
+    - name: Install Python 3.9.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8.5
+        python-version: 3.9.10
     - name: Install Python Dependencies
       run: |
         pip install --upgrade pip setuptools

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.8
+    python: python3.9
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
@@ -24,4 +24,4 @@ repos:
     rev: 22.10.0
     hooks:
     -   id: black
-        language_version: python3.8
+        language_version: python3.9

--- a/example/some_module/some_api.py
+++ b/example/some_module/some_api.py
@@ -28,3 +28,10 @@ class SomeAPI:
     @property
     def some_property(self):
         return "foo"
+
+    @mock_if("ENV", "test")
+    def mocked_method(self):
+        return "mocked"
+
+    def unmocked_method(self):
+        return "unmocked"

--- a/example/tests/some_other_module_test.py
+++ b/example/tests/some_other_module_test.py
@@ -4,6 +4,7 @@ from some_module.some_api import SomeAPI
 
 from expectise import Expect
 from expectise import Expectations
+from expectise import mock
 from expectise.exceptions import EnvironmentError
 from expectise.exceptions import ExpectationError
 
@@ -123,3 +124,17 @@ def test_disable():
         Expect.disable_mock("SomeAPI", "update_attribute")
         some_api.update_attribute("new_value")
         assert some_api.my_attribute == "new_value"
+
+
+def test_tear_down_disables_temporary_mocks():
+    # This test ensures that calling mock(...) and then
+    # tearing down (by exiting the context manager)
+    # fully removes the Mock and does not impact future tests
+    with Expectations():
+        some_api = SomeAPI()
+        mock(SomeAPI, SomeAPI.unmocked_method, "ENV", "test")
+        Expect("SomeAPI").to_receive("unmocked_method").and_return("mocked")
+
+        assert some_api.unmocked_method() == "mocked"
+
+    assert some_api.unmocked_method() == "unmocked"

--- a/example/tests/some_other_module_test.py
+++ b/example/tests/some_other_module_test.py
@@ -138,3 +138,18 @@ def test_tear_down_disables_temporary_mocks():
         assert some_api.unmocked_method() == "mocked"
 
     assert some_api.unmocked_method() == "unmocked"
+
+
+def test_tear_down_keeps_permanent_mocks():
+    # This test ensures that permanent mocks (i.e. those
+    # created with mock_if - wen in the test environment)
+    # are not removed by tear_down
+    with Expectations():
+        some_api = SomeAPI()
+
+        Expect("SomeAPI").to_receive("mocked_method").and_return("mocked")
+
+        assert some_api.mocked_method() == "mocked"
+
+    with pytest.raises(EnvironmentError):
+        some_api.mocked_method()

--- a/expectise/mocks.py
+++ b/expectise/mocks.py
@@ -4,12 +4,13 @@ from typing import Type
 
 from .exceptions import EnvironmentError
 from .expect import Expect
+from .expect import Lifespan
 
 
 class Mock:
     """Represent a mocked method and its behaviour depending on the environment context."""
 
-    def __init__(self, klass: Type, method: Callable, env_name: str, env_value: str) -> None:
+    def __init__(self, klass: Type, method: Callable, env_name: str, env_value: str, lifespan: Lifespan) -> None:
         self.klass = klass
         self.method = method
         self.is_classmethod = isinstance(method, classmethod)
@@ -17,6 +18,7 @@ class Mock:
         self.is_property = isinstance(method, property)
         self.env_name = env_name
         self.env_value = env_value
+        self.lifespan = lifespan
 
     @property
     def name(self) -> str:
@@ -58,7 +60,7 @@ class Mock:
 
 def mock(klass: Type, method: Callable, env_name: str, env_value: str) -> None:
     """Enable mocking of an object method by replacing it with a surrogate, requiring subsequent `Expect` statements."""
-    Mock(klass, method, env_name, env_value).enable()
+    Mock(klass, method, env_name, env_value, lifespan=Lifespan.TEMPORARY).enable()
 
 
 def mock_if(env_name: str, env_value: str) -> Type:
@@ -78,7 +80,7 @@ def mock_if(env_name: str, env_value: str) -> Type:
             * if the environment conditions are met, the method is marked as to be mocked for later calls
             * if not, the method is left unchanged.
             """
-            self.mock = Mock(None, method, env_name, env_value)
+            self.mock = Mock(None, method, env_name, env_value, lifespan=Lifespan.PERMANENT)
 
         def __set_name__(self, owner: Type, name: str) -> None:
             """


### PR DESCRIPTION
# Description

Previously mocks were not being correctly handled during tear_down:

* permanent mocks (when in the test environment) such as those created with `mock_if` persisted to following tests after the tear_down operation was called ✅ 
* temporary mocks (such as those created with mock(...) also persisted after tear_down 🟥 

This had a side-effect which caused `disable_mock` to be ineffective for mocks created with mock(...) since these would just be set_up again during tear down.

# Solution

* Added the concept of Mock lifecycle: TEMPORARY and PERMANENT
* Temporary mocks (i.e.: mock(...)) are disabled and popped from the method_h dictionary during tear_down
* Permanent mocks keep the same behaviour as before

Added two tests to cover each of the cases.

## Other considerations

* Added the Lifecycle enum to the expectise.py module (rather than the possibly more logical mocks.py module) to avoid circular import issues.