### PR TITLE
Raise first error and not override it

### DIFF
--- a/expectise/expect.py
+++ b/expectise/expect.py
@@ -6,6 +6,7 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import TYPE_CHECKING
 
 from .diff import Diff
@@ -262,7 +263,7 @@ class Expect(object):
         cls.method_h[(class_name, method_name)]["mock"].disable()
 
     @classmethod
-    def tear_down(cls) -> None:
+    def tear_down(cls, execution_error: Optional[Exception] = None) -> None:
         """Check for any method called less times than expected, and raise an AssertionError is any is found."""
         message = ""
         temporary_mocks = []
@@ -284,6 +285,10 @@ class Expect(object):
         # Fully removing all references to temporary mocks
         for key in temporary_mocks:
             cls.method_h.pop(key)
+
+        # In case an exception was raised during the test, raising it again
+        if execution_error:
+            raise execution_error
 
         # If some calls are still expected, message is not empty, so asserting False with the appropriate message
         assert not message, message

--- a/expectise/expectations.py
+++ b/expectise/expectations.py
@@ -10,5 +10,5 @@ class Expectations:
     def __enter__(self):
         pass
 
-    def __exit__(self, type, value, traceback):
-        Expect.tear_down()
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        Expect.tear_down(exc_val)

--- a/expectise/mocks.py
+++ b/expectise/mocks.py
@@ -102,5 +102,5 @@ def mock_if(env_name: str, env_value: str) -> Type:
 
 
 def tear_down():
-    """Reset mocking behaviour so that further tests can be run without any interference."""
+    """Reset mocking behavior so that further tests can be run without any interference."""
     Expect.tear_down()


### PR DESCRIPTION
Currently whenever an error occurs it's overridden by the raise clause in the tear_down function.

This makes debugging more tedious, specially for long test function.
In case an error occurs, this PR raises the first error that occurred and failed the test.